### PR TITLE
fix: correct TPM phase error based on coordinate definition

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,4 +11,5 @@ Please select a feature from the sidebar on the left.
 - **Job Generator**: Generate execution scripts for the Apollo server
 - **EPH/OBS Generator**: Generate input data with periodic scaling
 - **Data Integration**: Integrate infrared and visible light data (under development)
+- **Phase Corrector**: Emergency tool for fixing TPM phase errors (New)
 """)

--- a/pages/07_phase_corrector.py
+++ b/pages/07_phase_corrector.py
@@ -1,0 +1,43 @@
+# pages/07_phase_corrector.py
+import streamlit as st
+import pandas as pd
+import io
+from src.data_processor import apply_tpm_phase_correction
+
+st.set_page_config(page_title="Phase Corrector", layout="wide")
+st.title("🔧 TPM Phase Corrector (Emergency Fix)")
+
+st.markdown("""
+### Overview
+This corrects phase discrepancies arising from the definition of the coordinate system used in TPM calculations.
+The following correction formula is applied to data rows where `category == 'IR'` to calculate a new time (time).
+- `time = time + (lon_a - 90) / 360 * (period / 86400)`
+""")
+
+uploaded_file = st.file_uploader("Upload Unified (or TPM-only) Parquet File", type="parquet")
+
+if uploaded_file:
+    df = pd.read_parquet(uploaded_file)
+    
+    st.subheader("Before Correction")
+    st.dataframe(df.head())
+
+    if st.button("Apply Phase Correction"):
+        with st.spinner("Calculating..."):
+            df_corrected = apply_tpm_phase_correction(df)
+
+        st.success("Correction complete!")
+
+        st.subheader("After Correction (Preview)")
+        st.dataframe(df_corrected.head())
+
+        # Prepare for download
+        out_bio = io.BytesIO()
+        df_corrected.to_parquet(out_bio, index=False, compression='zstd')
+        
+        st.download_button(
+            label="Download Corrected Parquet",
+            data=out_bio.getvalue(),
+            file_name="corrected_tpm_data.parquet",
+            mime="application/octet-stream"
+        )

--- a/src/data_processor.py
+++ b/src/data_processor.py
@@ -48,3 +48,32 @@ def integrate_tpm_and_hapke(df_tpm, dict_hapke):
         unified_chunks.append(group)
     
     return pd.concat(unified_chunks, ignore_index=True)
+
+def apply_tpm_phase_correction(df):
+    """
+    Apply a phase correction due to the coordinate system to TPM data (category == 'IR').
+    Correction formula: time = time + (lon_a - 90) / 360 * (period / 86400)
+    """
+    df_corr = df.copy()
+    SECONDS_IN_DAY = 86400
+
+    # Extract only IR category
+    mask = df_corr['category'] == 'IR'
+    mask = df_corr['category'] == 'IR'
+    
+    if mask.any():
+        # Convert period from string like "100s" to numeric
+        def get_period_val(p):
+            if isinstance(p, str):
+                return float(p.replace('s', ''))
+            return float(p)
+
+        # Execute the correction calculation
+        # Use loc to safely update values
+        lon_a = df_corr.loc[mask, 'lon_a']
+        period_vals = df_corr.loc[mask, 'period'].apply(get_period_val)
+        
+        correction = (lon_a - 90) / 360 * (period_vals / SECONDS_IN_DAY)
+        df_corr.loc[mask, 'time'] += correction
+        
+    return df_corr


### PR DESCRIPTION
## Overview
We have implemented a function to correct phase (time) discrepancies arising from the definition of the coordinate system in TPM calculation results.

## Changes
- `src/data_processor.py`: Added logic for emergency correction: `apply_tpm_phase_correction`
- `pages/07_phase_corrector.py`: Implemented a tool to batch-correct and resave Parquet files via the web UI

## Correction Formula
`time = time + (lon_a - 90) / 360 * (period / 86400)`

## Related Issue
- Closes #10 