### PR TITLE
fix: restore vendored pyhapke sources

### DIFF
--- a/src/pyhapke/constants.py
+++ b/src/pyhapke/constants.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+# CONSTANTS #################
+
+e = 0
+i = np.pi/6
+g = np.pi/6
+
+# Phase
+P_REG = 0.8098 #Calculated from Legendre polynomials, b = -0.4 c = 0.25
+# From Pascuzzo et al. 2022
+(b,c) = (0.5,0.8)
+P_ICE = (1-c) * (1 - b**2) / (1 - 2 * b * np.cos(g) + b**2) ** (3/2) + c * (1 - b**2) / (1 + 2 * b * np.cos(g) + b**2)**(3/2)
+
+# Density (g/cm^3)
+RHO_ICE = 0.917
+RHO_REG = 1.5 # From Lunar Sourcebook
+
+# Diameters
+
+D_ICE = 100
+D_REG = 100
+
+PEAK_IDX = 128 # Index of 0.7 microns in the OC dataset

--- a/src/pyhapke/hapkeFuncs.py
+++ b/src/pyhapke/hapkeFuncs.py
@@ -1,0 +1,164 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import scipy.optimize
+import scipy
+
+from .constants import *
+
+
+def compute_H(ssa, x):
+    """Method for computing Chandrasekhar's H function, developed by Shuai Li
+
+    Args:
+        ssa (float or np.ndarray): single scattering albedo
+        x (float): mu or mu0, i.e. cosines of incidence and emmittence angles
+    """
+    y = np.sqrt(1-ssa)
+    r0 = (1-y)/(1+y)
+
+    Hinv = 1 - (1 - y) * x * (r0 + (1 - 0.5 * r0 - r0 * x) * np.log((1+x)/x))
+    return 1/Hinv
+
+
+def compute_H2(ssa, x):
+    """Alternative method for computing Chandrasekhar's H function, developed by Shuai Li
+
+    Args:
+        ssa (float or np.ndarray): single scattering albedo
+        x (float): mu or mu0, i.e. cosines of incidence and emmittence angles
+    """
+    y = np.sqrt(1-ssa)
+
+    arg = (1+x)/x
+    a = x - 0.5 * x * np.log(arg) - x ** 2 * np.log(arg)
+    b = x * np.log(arg)
+
+    num = 1 + y
+    den = 1 + y - a * (1 - y)**2 - b * (1 - y**2)
+
+    return num/den
+
+
+def compute_B(poros, g=np.pi/6):
+    """ Computes the opposition effect B(g), using Hapke 9.22
+
+    Args:
+        g (float or list_like, default = np.pi/6): phase angle
+
+    Returns:
+        B: opposition effect
+    """
+
+    O = poros
+    B0 = 1
+    h = -3/8 * np.log(1 - O)
+
+    return B0/(1 + (1/h) * np.tan(g/2))
+
+
+def convert_oc_to_ssa(wl, n, k, D):
+    """Converts empircal data about the optical constant to single scattering albedo as a function of wavelength
+
+    Args:
+        wl (nd.array): Wavelength in microns
+        n (nd.array): Real index of refraction
+        k (nd.array): Complex part of index of refraction
+        D (np.float): particle size in microns
+
+    Returns:
+        _type_: _description_
+    """
+
+    alpha = 4 * np.pi * n * k/wl
+    Dave = 2/3 * (n ** 2 - ((n ** 2 - 1) ** (3/2))/n) * D
+
+    se = ((n - 1) ** 2 + k ** 2)/((n + 1) ** 2 + k ** 2) + 0.05
+    si = 1 - 4/(n * (n + 1) ** 2)
+    Theta = np.exp(-alpha * Dave)
+
+    ssa = se + (1 - se) * ((1 - si) * Theta)/(1 - si * Theta)
+
+    return ssa
+
+
+def compute_mixed_P(Mis, ssas, Ps=[P_REG, P_ICE], densities=[RHO_REG, RHO_ICE], diameters=[D_REG, D_ICE]):
+    """ Compute the mixed phase function of different materials (especially ice and regolith). Default parameters
+    contain values for phase function P, density, and diameter for regolith and ice, in that order.
+
+    Args:
+        Ps (list_like): Phase function P evaluated at angle g (standard is pi/6)
+        Mis (list_like): Mass fractions, should sum to 1
+        densities (list_like): Densities. Units are arbitrary as long as they are consistent between all densities.
+        ssas (list_like): Single scattering albedo for each component. Each element in the list can be an nd_array containing ssa as a function of wavelength
+        diameters (list_like): Average diameter for each component.
+
+    Returns:
+        Pout (float or list_like): Mixed Phase function value
+    """
+    num = 0
+    den = 0
+
+    for i in range(len(Ps)):
+        P = Ps[i]
+        M = Mis[i]
+        rho = densities[i]
+        ssa = ssas[i]
+        d = diameters[i]
+
+        num += M * P * ssa/(rho * d)
+        den += M * ssa/(rho * d)
+
+    return num/den
+
+
+def compute_mixed_ssa(Mis, ssas, densities=[RHO_REG, RHO_ICE], diameters=[D_REG, D_ICE]):
+    """ Compute the mixed single scattering albedo  of different materials (especially ice and regolith). Default parameters
+    contain values density, and diameter for regolith and ice, in that order.
+
+    Args:
+        Mis (list_like): Mass fractions, should sum to 1
+        densities (list_like): Densities. Units are arbitrary as long as they are consistent between all densities.
+        ssas (list_like): Single scattering albedo for each component. Each element in the list can be an nd_array containing ssa as a function of wavelength
+        diameters (list_like): Average diameter for each component.
+
+    Returns:
+        ssa_ave (float or list_like): Averaged single scattering albedo
+    """
+    num = 0
+    den = 0
+
+    for i in range(len(Mis)):
+        M = Mis[i]
+        rho = densities[i]
+        ssa = ssas[i]
+        d = diameters[i]
+
+        num += M * ssa/(rho)
+        den += M / (rho)
+    return num/den
+
+
+def compute_P_REG_dependent(g):
+    """
+    Computes the phase function P(g) for regolith using Double Henyey-Greenstein function.
+    Parameters based on constants.py comments: b = -0.4, c = 0.25
+
+    Args:
+        g (float): Phase angle in radians
+
+    Returns:
+        float: Phase function value P(g)
+    """
+    # constants.pyのコメントにあるパラメータ
+    b = -0.4
+    c = 0.25
+
+    # P_ICEと同じ形式 (Double Henyey-Greenstein) で計算
+    # 第1項: 順方向散乱的な成分 (パラメータb)
+    term1 = (1 - c) * (1 - b**2) / ((1 - 2 * b * np.cos(g) + b**2) ** (3/2))
+
+    # 第2項: 後方散乱的な成分 (パラメータ-b に相当する項、あるいは符号反転項)
+    # P_ICEの実装に合わせて、分母の符号を + にした項（これは -b を代入したのと同じ）を足し合わせます
+    term2 = c * (1 - b**2) / ((1 + 2 * b * np.cos(g) + b**2) ** (3/2))
+
+    return term1 + term2

--- a/src/pyhapke/hapkeRTM.py
+++ b/src/pyhapke/hapkeRTM.py
@@ -1,0 +1,164 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import scipy.optimize
+import scipy
+
+from .constants import *
+from .hapkeFuncs import *
+
+
+class HapkeRTM:
+    def __init__(self, i=0, e=np.pi/6, g=np.pi/6, P=P_REG, wl=None, poros=0.41):
+        """Initialize an instance of the Hapke Radiative Transfer Model, which has tools to calculate ssa from reflectance, and vice versa
+
+        Args:
+            i (float, optional): Incidence angle in radians. Defaults to np.pi/6.
+            e (float, optional): Emmitance angle in radians. Defaults to 0.
+            g (float, optional): Phase angle in radiance. Defaults to np.pi/6.
+            P (float or nd.array, optional): Phase function value at angle g.  Defaults to P_REG, regolith at 30 deg phase. Can also be input
+            as an array with respect to wavelength
+            wl (nd.array, optional): Wavelengths corresponding to each entry in P, if P is a nd.array. Defaults to None.
+        """
+        self.mu0 = np.cos(i)
+        self.mu = np.cos(e)
+        self.B = compute_B(poros=poros, g=g)
+        # self.B = 0.4248
+        self.P = P
+        self.wl = wl
+        self.hapke_polynomial = None
+
+        pass
+
+    def hapke_function_REFF(self, ssa):
+        """Function R(omega), assuming other parameters are known. This is 
+        the REFF version of the function (Hapke equation 10.4), computing the reflectance factor (reflectance coefficient)
+
+        Args:
+            ssa (float or nd.array): single scattering albedo
+
+        Returns:
+            float or nd.array: Reflectance factor
+        """
+        mu0 = self.mu0
+        mu = self.mu
+        B = self.B
+        P = self.P
+
+        # Compute H-funct
+        H = compute_H2(ssa, mu)
+        H0 = compute_H2(ssa, mu0)
+
+        # R = (ssa/4) * mu0 / (mu0 + mu) * ((1 + B) * P + H * H0 - 1)
+        R = (ssa/4) / (mu0 + mu) * ((1 + B) * P + H * H0 - 1)
+
+        return R
+
+    def hapke_function_RADF(self, ssa):
+        """Function R(omega), assuming other parameters are known. This is 
+        the RADF version of the function (Hapke equation 10.5), which computes I/F radiance.
+
+        Args:
+            ssa (float or nd.array): single scattering albedo
+
+        Returns:
+            float or nd.array: I/F radiance
+        """
+        mu0 = self.mu0
+        mu = self.mu
+        B = self.B
+        P = self.P
+
+        # Compute H-funct
+        H = compute_H(ssa, mu)
+        H0 = compute_H(ssa, mu0)
+
+        # R = (ssa/4) * mu0 / (mu0 + mu) * ((1 + B) * P + H * H0 - 1)
+        R = (ssa/4) * mu0 / (mu0 + mu) * ((1 + B) * P + H * H0 - 1)
+
+        return R
+
+    def hapke_function_BDRF(self, ssa):
+        """Function R(omega), assuming other parameters are known. This is 
+        the BDRF version of the function (Hapke equation 10.5), computing Bi-Directional Reflectance
+
+        Args:
+            ssa (float or nd.array): single scattering albedo
+
+        Returns:
+            float or nd.array: Bidirectional reflectance distribution factor
+        """
+        mu0 = self.mu0
+        mu = self.mu
+        B = self.B
+        P = self.P
+
+        # Compute H-funct
+        H = compute_H2(ssa, mu)
+        H0 = compute_H2(ssa, mu0)
+
+        # R = (ssa/4) * mu0 / (mu0 + mu) * ((1 + B) * P + H * H0 - 1)
+        R = (ssa/4 / np.pi) / (mu0 + mu) * ((1 + B) * P + H * H0 - 1)
+
+        return R
+
+    def hapke_function(self, ssa):
+        """Function R(omega), assuming other parameters are known, where R is bidirectional reflectance
+
+        Args:
+            ssa (float or nd.array): single scattering albedo
+
+        Returns:
+            float or nd.array: Bidirectional reflectance
+        """
+        mu0 = self.mu0
+        mu = self.mu
+        B = self.B
+        P = self.P
+
+        # Compute H-funct
+        H = compute_H2(ssa, mu)
+        H0 = compute_H2(ssa, mu0)
+
+        # R = (ssa/4) * mu0 / (mu0 + mu) * ((1 + B) * P + H * H0 - 1)
+        R = (ssa/4 / np.pi) * mu0 / (mu0 + mu) * ((1 + B) * P + H * H0 - 1)
+
+        return R
+
+    def compute_ssa_from_R(self, R, method='lm', model="RADF"):
+        """Compute single scattering albedo given reflectance or radiance and input. By default, uses Levenberg-Marquardt algorithm as part of 
+        scipy.optimize.root. Hybr method (scipy default) not recommended, due to difficulty of finding simualted jacobian.
+
+        Args:
+            R (float or nd.array): Reflectance
+            method (str, optional): Root finding method from scipy.optimize.root. Defaults to 'lm'.
+            model (function, optional): Version of Hapke's model to compute ssa from. Defaults to hapke_function_REFF.
+        """
+
+        if model == "REFF":
+            def obj_func(ssa, R):
+                Rpred = self.hapke_function_REFF(ssa)
+                return Rpred - R
+        elif model == "BDRF":
+            def obj_func(ssa, R):
+                Rpred = self.hapke_function_BDRF(ssa)
+                return Rpred - R
+        elif model == "RADF":
+            def obj_func(ssa, R):
+                Rpred = self.hapke_function_RADF(ssa)
+                return Rpred - R
+        elif model is None:
+            def obj_func(ssa, R):
+                Rpred = self.hapke_function(ssa)
+                return Rpred - R
+
+        if type(R) is np.ndarray:
+            x0 = np.ones_like(R) * 0.5
+        else:
+            x0 = 0.5
+
+        sol = scipy.optimize.root(
+            fun=obj_func, x0=x0, args=(R), method=method, tol=1e-15)
+
+        return sol.x
+
+    # def calculate_hapke_polynomial(self, )


### PR DESCRIPTION
- Restore the vendored pyhapke source code under src/pyhapke to resolve the HapkeRTM import error
- Ensure it works without external dependencies (separate cloning or pip)